### PR TITLE
[README] Adds Windows installation instructions for scoop.

### DIFF
--- a/readme-cn.md
+++ b/readme-cn.md
@@ -34,6 +34,12 @@ arm64 系统:
 $ docker run --rm -it -p <listen-port>:<listen-port> -p <remote-port>:<remote-port> kevinwan/tproxy:v1-arm64 tproxy -l 0.0.0.0 -p <listen-port> -r host.docker.internal:<remote-port>
 ```
 
+Windows:
+
+```shell
+$ scoop install tproxy
+```
+
 ## 用法
 
 ```shell

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,12 @@ For arm64:
 $ docker run --rm -it -p <listen-port>:<listen-port> -p <remote-port>:<remote-port> kevinwan/tproxy:v1-arm64 tproxy -l 0.0.0.0 -p <listen-port> -r host.docker.internal:<remote-port>
 ```
 
+On Windows, you can use [scoop](https://scoop.sh/):
+
+```shell
+$ scoop install tproxy
+```
+
 ## Usages
 
 ```shell


### PR DESCRIPTION
Added Windows installation option via [scoop](https://scoop.sh/) which is raised in [scoop/Issue 3760](https://github.com/ScoopInstaller/Main/pull/3760) and added in [scoop/Issue 3759](https://github.com/ScoopInstaller/Main/issues/3759).

Example install on Windows 10 (via Windows Terminal):
![image](https://user-images.githubusercontent.com/68254/179705795-5bf08188-4750-4482-ab77-c0da6fed22e2.png)

We use your awesome work in a project and our build agent now picks it up from scoop.

I'm not able to add instructions to the readme-cn.md,  if you're able to recommend text to put instead, that would be great.